### PR TITLE
Training the Qwen3 model

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,6 +19,9 @@ jobs:
     - name: Install uv
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: Run lint
+      run: |
+        uvx ruff check
     - name: Run pytest
       run: |
         uv run --extra dev pytest -s tests

--- a/tests/models/test_qwen3.py
+++ b/tests/models/test_qwen3.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 import tempfile
 
-import jax.numpy as jnp
 from flax import nnx
 import numpy as np
 import safetensors.numpy

--- a/xtrain/models/qwen3.py
+++ b/xtrain/models/qwen3.py
@@ -1,7 +1,7 @@
 from flax import nnx
 import jax
 from jax import numpy as jnp
-from transformers import AutoConfig, Qwen3Config
+from transformers import Qwen3Config
 
 
 def Param(*shape: int, rngs: nnx.Rngs):

--- a/xtrain/utils.py
+++ b/xtrain/utils.py
@@ -1,6 +1,20 @@
 from flax import nnx
 from transformers import PretrainedConfig
 
+from xtrain import models
+
+
+def get_model_class(config: PretrainedConfig) -> nnx.Module:
+    "Get the correct model class based on the config."
+
+    for architecture in config.architectures or []:
+        if hasattr(models, architecture):
+            return getattr(models, architecture)
+
+    raise ValueError(
+        f"None of the architectures {config.architectures} is currently supported."
+    )
+
 
 def get_param_mapping(config: PretrainedConfig, model: nnx.Module) -> dict[tuple, str]:
     "Get the mapping from model parameter paths to safetensors keys."


### PR DESCRIPTION
This can be run with
```
uv run xtrain --model Qwen/Qwen3-0.6B --dataset roneneldan/TinyStories --output-dir /tmp --per-device-batch-size 2
```

You can e.g. serve the model with vllm via:
```
uv run --with huggingface_hub hf download Qwen/Qwen3-0.6B --local-dir qwen3
cp /tmp/model.safetensors qwen3/model.safetensors
uv run --with vllm vllm serve qwen3
```

Call the model:
```
curl http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
        "model": "qwen3",
        "prompt": "Once upon a time,",
        "max_tokens": 7,
        "temperature": 0
    }'
```

Note that currently the training happens in fp32 and there might still be bugs. More correctness tests will be performed and the model be optimized going forward.