### PR TITLE
Add mock tinker API

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -36,7 +36,7 @@ jobs:
         uv run --extra tinker --extra dev ty check
     - name: Run pytest
       run: |
-        uv run --extra dev pytest -s tests
+        uv run --extra tinker --extra dev pytest -s tests
     - name: Run a single training step
       run: |
         uv run tx train --model pcmoritz/qwen3-tiny-test --dataset mahiatlinux/TinyStories-GPT4-V2-50K-SUBSET --output-dir /tmp --batch-size 2 --max-steps 1 --optimizer-args '{"learning_rate": 0.002, "weight_decay": 0.1}'

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,7 +33,7 @@ jobs:
         uvx ruff check
     - name: Run type checking
       run: |
-        uvx ty check
+        uv run --extra tinker --extra dev ty check
     - name: Run pytest
       run: |
         uv run --extra dev pytest -s tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ tpu = [
     "jax[tpu]>=0.7.2",
 ]
 
+tinker = [
+    "tinker",
+    "fastapi[standard]",
+]
+
 dev = [
     "mkdocs",
     "mkdocs-material",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "mkdocs-material",
     "pytest",
     "torch",
+    "ty",
 ]
 
 [tool.setuptools]

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -1,0 +1,103 @@
+"""Tests for the Tinker API mock server using the real tinker client."""
+import pytest
+import subprocess
+import time
+import tinker
+from tinker import types
+
+
+@pytest.fixture(scope="module")
+def api_server():
+    """Start the FastAPI server for testing."""
+    process = subprocess.Popen(
+        ["uv", "run", "uvicorn", "tx.tinker.api:app", "--host", "0.0.0.0", "--port", "8000"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    # Give server a moment to start
+    time.sleep(2)
+
+    yield process
+
+    # Cleanup
+    process.terminate()
+    process.wait(timeout=5)
+
+
+@pytest.fixture
+def service_client(api_server):
+    """Create a service client connected to the test server."""
+    return tinker.ServiceClient(base_url="http://0.0.0.0:8000/", api_key="dummy")
+
+
+def test_example_workflow(service_client):
+    """Test the example workflow from the user."""
+    # Get server capabilities
+    print("\nAvailable models:")
+    for item in service_client.get_server_capabilities().supported_models:
+        print("- " + item.model_name)
+
+    base_model = "Qwen/Qwen3-8B"
+    training_client = service_client.create_lora_training_client(
+        base_model=base_model
+    )
+
+    tokenizer = training_client.get_tokenizer()
+    assert tokenizer is not None
+
+
+def test_training_workflow(service_client):
+    """Test a complete training workflow."""
+    base_model = "Qwen/Qwen3-8B"
+    training_client = service_client.create_lora_training_client(
+        base_model=base_model
+    )
+
+    tokenizer = training_client.get_tokenizer()
+
+    # Create training examples
+    examples = [
+        {"prompt": "Question: What is 2+2?\nAnswer:", "completion": " 4"},
+        {"prompt": "Question: What color is the sky?\nAnswer:", "completion": " Blue"},
+    ]
+
+    # Process examples into Datum objects
+    processed_examples = []
+    for example in examples:
+        prompt_tokens = tokenizer.encode(example["prompt"])
+        completion_tokens = tokenizer.encode(example["completion"])
+
+        # Combine tokens
+        all_tokens = prompt_tokens + completion_tokens
+
+        # Create weights: 0 for prompt, 1 for completion
+        weights = [0.0] * len(prompt_tokens) + [1.0] * len(completion_tokens)
+
+        # Target tokens are shifted by 1
+        target_tokens = all_tokens[1:] + [tokenizer.eos_token_id]
+
+        # Create Datum
+        datum = types.Datum(
+            model_input=types.ModelInput.from_ints(all_tokens[:-1]),
+            loss_fn_inputs={
+                "weights": weights[:-1],
+                "target_tokens": target_tokens[:-1],
+            }
+        )
+        processed_examples.append(datum)
+
+    # Run training step
+    fwdbwd_future = training_client.forward_backward(processed_examples, "cross_entropy")
+    optim_future = training_client.optim_step(types.AdamParams(learning_rate=1e-4))
+
+    # Get results
+    fwdbwd_result = fwdbwd_future.result()
+    optim_result = optim_future.result()
+
+    assert fwdbwd_result is not None
+    assert optim_result is not None
+    assert fwdbwd_result.loss_fn_output_type == "scalar"
+    assert len(fwdbwd_result.loss_fn_outputs) > 0
+
+    print(f"\nTraining completed! Loss type: {fwdbwd_result.loss_fn_output_type}")

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -1,7 +1,6 @@
 """Tests for the Tinker API mock server using the real tinker client."""
 import pytest
 import subprocess
-import time
 import tinker
 from tinker import types
 
@@ -14,9 +13,6 @@ def api_server():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE
     )
-
-    # Give server a moment to start
-    time.sleep(2)
 
     yield process
 

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -10,7 +10,7 @@ from tinker import types
 def api_server():
     """Start the FastAPI server for testing."""
     process = subprocess.Popen(
-        ["uv", "run", "uvicorn", "tx.tinker.api:app", "--host", "0.0.0.0", "--port", "8000"],
+        ["uv", "run", "--extra", "tinker", "uvicorn", "tx.tinker.api:app", "--host", "0.0.0.0", "--port", "8000"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE
     )
@@ -34,9 +34,9 @@ def service_client(api_server):
 def test_example_workflow(service_client):
     """Test the example workflow from the user."""
     # Get server capabilities
-    print("\nAvailable models:")
-    for item in service_client.get_server_capabilities().supported_models:
-        print("- " + item.model_name)
+    capabilities = service_client.get_server_capabilities()
+    model_names = [item.model_name for item in capabilities.supported_models]
+    assert "Qwen/Qwen3-8B" in model_names
 
     base_model = "Qwen/Qwen3-8B"
     training_client = service_client.create_lora_training_client(
@@ -99,5 +99,3 @@ def test_training_workflow(service_client):
     assert optim_result is not None
     assert fwdbwd_result.loss_fn_output_type == "scalar"
     assert len(fwdbwd_result.loss_fn_outputs) > 0
-
-    print(f"\nTraining completed! Loss type: {fwdbwd_result.loss_fn_output_type}")

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -27,20 +27,11 @@ def service_client(api_server):
     return tinker.ServiceClient(base_url="http://0.0.0.0:8000/", api_key="dummy")
 
 
-def test_example_workflow(service_client):
-    """Test the example workflow from the user."""
-    # Get server capabilities
+def test_capabilities(service_client):
+    """Test the get_server_capabilities endpoint."""
     capabilities = service_client.get_server_capabilities()
     model_names = [item.model_name for item in capabilities.supported_models]
     assert "Qwen/Qwen3-8B" in model_names
-
-    base_model = "Qwen/Qwen3-8B"
-    training_client = service_client.create_lora_training_client(
-        base_model=base_model
-    )
-
-    tokenizer = training_client.get_tokenizer()
-    assert tokenizer is not None
 
 
 def test_training_workflow(service_client):

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -7,7 +7,6 @@ app = FastAPI(title="Tinker API Mock", version="1.0.0")
 
 # In-memory storage for models
 models_db: Dict[str, Dict[str, Any]] = {}
-checkpoints_db: Dict[str, List[Dict[str, Any]]] = {}
 futures_db: Dict[str, Dict[str, Any]] = {}
 
 
@@ -45,16 +44,6 @@ class ModelInfoResponse(BaseModel):
     model_data: ModelData
 
 
-class UnloadModelResponse(BaseModel):
-    model_id: str
-    status: str = "unloaded"
-
-
-class ForwardInput(BaseModel):
-    input_ids: List[List[int]]
-    attention_mask: Optional[List[List[int]]] = None
-
-
 class ForwardBackwardInput(BaseModel):
     model_id: str
     forward_backward_input: Dict[str, Any]
@@ -71,58 +60,6 @@ class OptimStepRequest(BaseModel):
     model_id: str
     adam_params: AdamParams
     type: Optional[str] = None
-
-
-class SamplingParams(BaseModel):
-    temperature: float = 1.0
-    top_p: float = 1.0
-    top_k: int = -1
-    max_tokens: int = 100
-    stop: Optional[List[str]] = None
-
-
-class SampleRequest(BaseModel):
-    prompt: str
-    sampling_params: SamplingParams
-    num_samples: int = 1
-    base_model: Optional[str] = None
-    model_path: Optional[str] = None
-
-
-class SampleResponse(BaseModel):
-    samples: List[str]
-    prompt: str
-
-
-class SaveWeightsRequest(BaseModel):
-    model_id: str
-    path: Optional[str] = None
-    type: Optional[str] = None
-
-
-class SaveWeightsResponse(BaseModel):
-    model_id: str
-    path: str
-    status: str = "saved"
-
-
-class LoadWeightsRequest(BaseModel):
-    model_id: str
-    path: str
-    type: Optional[str] = None
-
-
-class LoadWeightsResponse(BaseModel):
-    model_id: str
-    path: str
-    status: str = "loaded"
-
-
-class Checkpoint(BaseModel):
-    checkpoint_id: str
-    model_id: str
-    path: str
-    created_at: str
 
 
 class FutureResponse(BaseModel):
@@ -175,7 +112,6 @@ async def create_model(request: CreateModelRequest):
     }
 
     models_db[model_id] = model_data
-    checkpoints_db[model_id] = []
 
     # Store the future result
     futures_db[request_id] = model_data
@@ -212,28 +148,6 @@ async def get_model_info(request: GetInfoRequest):
         status=model["status"],
         model_data=model_data
     )
-
-
-@app.post("/api/v1/unload_model", response_model=UnloadModelResponse)
-async def unload_model(model_id: str, type: Optional[str] = None):
-    """Unload model weights and end user session."""
-    if model_id not in models_db:
-        raise HTTPException(status_code=404, detail="Model not found")
-
-    models_db[model_id]["status"] = "unloaded"
-
-    return UnloadModelResponse(model_id=model_id, status="unloaded")
-
-
-# Training endpoints
-@app.post("/api/v1/forward", response_model=FutureResponse)
-async def forward(model_id: str, forward_input: ForwardInput):
-    """Perform forward pass through the model."""
-    if model_id not in models_db:
-        raise HTTPException(status_code=404, detail="Model not found")
-
-    future_id = f"future_{uuid4().hex[:8]}"
-    return FutureResponse(future_id=future_id, status="completed")
 
 
 @app.post("/api/v1/forward_backward", response_model=FutureResponse)
@@ -277,101 +191,6 @@ async def optim_step(request: OptimStepRequest):
     return FutureResponse(future_id=future_id, status="completed", request_id=request_id)
 
 
-# Sampling endpoints
-@app.post("/api/v1/sample", response_model=SampleResponse)
-async def sample(request: SampleRequest):
-    """Generate outputs from the model."""
-    samples = [
-        f"Generated sample {i+1} for prompt: {request.prompt}"
-        for i in range(request.num_samples)
-    ]
-
-    return SampleResponse(samples=samples, prompt=request.prompt)
-
-
-@app.post("/api/v1/asample", response_model=FutureResponse)
-async def asample(request: SampleRequest):
-    """Async generate outputs from the model."""
-    future_id = f"future_{uuid4().hex[:8]}"
-    return FutureResponse(future_id=future_id, status="pending")
-
-
-# Weights endpoints
-@app.post("/api/v1/save_weights", response_model=SaveWeightsResponse)
-async def save_weights(request: SaveWeightsRequest):
-    """Save current model weights to disk."""
-    if request.model_id not in models_db:
-        raise HTTPException(status_code=404, detail="Model not found")
-
-    path = request.path or f"/checkpoints/{request.model_id}/weights.safetensors"
-
-    # Add checkpoint to the list
-    checkpoint = {
-        "checkpoint_id": f"ckpt_{uuid4().hex[:8]}",
-        "model_id": request.model_id,
-        "path": path,
-        "created_at": "2025-10-01T00:00:00Z"
-    }
-    checkpoints_db[request.model_id].append(checkpoint)
-
-    return SaveWeightsResponse(model_id=request.model_id, path=path, status="saved")
-
-
-@app.post("/api/v1/load_weights", response_model=LoadWeightsResponse)
-async def load_weights(request: LoadWeightsRequest):
-    """Load model weights from disk."""
-    if request.model_id not in models_db:
-        raise HTTPException(status_code=404, detail="Model not found")
-
-    return LoadWeightsResponse(model_id=request.model_id, path=request.path, status="loaded")
-
-
-@app.post("/api/v1/save_weights_for_sampler", response_model=SaveWeightsResponse)
-async def save_weights_for_sampler(request: SaveWeightsRequest):
-    """Save weights compatible with sampling/inference servers."""
-    if request.model_id not in models_db:
-        raise HTTPException(status_code=404, detail="Model not found")
-
-    path = request.path or f"/checkpoints/{request.model_id}/sampler_weights.safetensors"
-
-    return SaveWeightsResponse(model_id=request.model_id, path=path, status="saved")
-
-
-@app.get("/api/v1/models/{model_id}/checkpoints", response_model=List[Checkpoint])
-async def list_checkpoints(model_id: str):
-    """List available model checkpoints."""
-    if model_id not in models_db:
-        raise HTTPException(status_code=404, detail="Model not found")
-
-    return [
-        Checkpoint(
-            checkpoint_id=ckpt["checkpoint_id"],
-            model_id=ckpt["model_id"],
-            path=ckpt["path"],
-            created_at=ckpt["created_at"]
-        )
-        for ckpt in checkpoints_db.get(model_id, [])
-    ]
-
-
-@app.delete("/api/v1/training_runs/{model_id}/checkpoints/{checkpoint_id}")
-async def delete_checkpoint(model_id: str, checkpoint_id: str):
-    """Delete a checkpoint for a specific training run."""
-    if model_id not in models_db:
-        raise HTTPException(status_code=404, detail="Model not found")
-
-    checkpoints = checkpoints_db.get(model_id, [])
-    original_len = len(checkpoints)
-    checkpoints_db[model_id] = [
-        ckpt for ckpt in checkpoints if ckpt["checkpoint_id"] != checkpoint_id
-    ]
-
-    if len(checkpoints_db[model_id]) == original_len:
-        raise HTTPException(status_code=404, detail="Checkpoint not found")
-
-    return {"status": "deleted", "checkpoint_id": checkpoint_id}
-
-
 # Service endpoints
 @app.get("/api/v1/get_server_capabilities", response_model=GetServerCapabilitiesResponse)
 async def get_server_capabilities():
@@ -412,15 +231,10 @@ async def root():
         "name": "Tinker API Mock",
         "version": "1.0.0",
         "endpoints": {
-            "models": ["/api/v1/create_model", "/api/v1/get_info", "/api/v1/unload_model"],
-            "training": ["/api/v1/forward", "/api/v1/forward_backward", "/api/v1/optim_step"],
-            "sampling": ["/api/v1/sample", "/api/v1/asample"],
-            "weights": [
-                "/api/v1/save_weights",
-                "/api/v1/load_weights",
-                "/api/v1/save_weights_for_sampler",
-                "/api/v1/models/{model_id}/checkpoints"
-            ],
+            "models": ["/api/v1/create_model", "/api/v1/get_info"],
+            "training": ["/api/v1/forward_backward", "/api/v1/optim_step"],
+            "futures": ["/api/v1/retrieve_future"],
+            "service": ["/api/v1/get_server_capabilities"],
             "telemetry": ["/api/v1/telemetry"]
         }
     }

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -263,7 +263,12 @@ async def optim_step(request: OptimStepRequest):
         raise HTTPException(status_code=404, detail="Model not found")
 
     future_id = f"future_{uuid4().hex[:8]}"
-    return FutureResponse(future_id=future_id, status="completed")
+    request_id = f"req_{uuid4().hex[:8]}"
+
+    # Store empty result for optim_step
+    futures_db[request_id] = {}
+
+    return FutureResponse(future_id=future_id, status="completed", request_id=request_id)
 
 
 # Sampling endpoints

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from typing import Literal, Any
 from uuid import uuid4
 
-app = FastAPI(title="Tinker API Mock", version="1.0.0")
+app = FastAPI(title="Tinker API Mock", version="0.0.1")
 
 # In-memory storage for models
 models_db: dict[str, dict[str, Any]] = {}
@@ -156,7 +156,6 @@ async def forward_backward(request: ForwardBackwardInput):
     if request.model_id not in models_db:
         raise HTTPException(status_code=404, detail="Model not found")
 
-    future_id = f"future_{uuid4().hex[:8]}"
     request_id = f"req_{uuid4().hex[:8]}"
 
     # Store the future result with required fields
@@ -173,7 +172,7 @@ async def forward_backward(request: ForwardBackwardInput):
         "metrics": {}
     }
 
-    return FutureResponse(future_id=future_id, status="completed", request_id=request_id)
+    return FutureResponse(future_id=request_id, status="completed", request_id=request_id)
 
 
 @app.post("/api/v1/optim_step", response_model=FutureResponse)
@@ -182,13 +181,12 @@ async def optim_step(request: OptimStepRequest):
     if request.model_id not in models_db:
         raise HTTPException(status_code=404, detail="Model not found")
 
-    future_id = f"future_{uuid4().hex[:8]}"
     request_id = f"req_{uuid4().hex[:8]}"
 
     # Store empty result for optim_step
     futures_db[request_id] = {}
 
-    return FutureResponse(future_id=future_id, status="completed", request_id=request_id)
+    return FutureResponse(future_id=request_id, status="completed", request_id=request_id)
 
 
 # Service endpoints

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -180,7 +180,13 @@ async def create_model(request: CreateModelRequest):
     # Store the future result
     futures_db[request_id] = model_data
 
-    return CreateModelResponse(**model_data)
+    return CreateModelResponse(
+        model_id=model_id,
+        base_model=request.base_model,
+        lora_config=request.lora_config,
+        status="created",
+        request_id=request_id
+    )
 
 
 class GetInfoRequest(BaseModel):
@@ -337,7 +343,15 @@ async def list_checkpoints(model_id: str):
     if model_id not in models_db:
         raise HTTPException(status_code=404, detail="Model not found")
 
-    return [Checkpoint(**ckpt) for ckpt in checkpoints_db.get(model_id, [])]
+    return [
+        Checkpoint(
+            checkpoint_id=ckpt["checkpoint_id"],
+            model_id=ckpt["model_id"],
+            path=ckpt["path"],
+            created_at=ckpt["created_at"]
+        )
+        for ckpt in checkpoints_db.get(model_id, [])
+    ]
 
 
 @app.delete("/api/v1/training_runs/{model_id}/checkpoints/{checkpoint_id}")

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -33,11 +33,18 @@ class CreateModelResponse(BaseModel):
     request_id: str
 
 
+class ModelData(BaseModel):
+    base_model: str
+    lora_config: Optional[LoRAConfig] = None
+    model_name: Optional[str] = None
+
+
 class ModelInfoResponse(BaseModel):
     model_id: str
     base_model: str
     lora_config: Optional[LoRAConfig] = None
     status: str
+    model_data: ModelData
 
 
 class UnloadModelResponse(BaseModel):
@@ -189,7 +196,20 @@ async def get_model_info(request: GetInfoRequest):
     if request.model_id not in models_db:
         raise HTTPException(status_code=404, detail="Model not found")
 
-    return ModelInfoResponse(**models_db[request.model_id])
+    model = models_db[request.model_id]
+    model_data = ModelData(
+        base_model=model["base_model"],
+        lora_config=model["lora_config"],
+        model_name=model["base_model"]
+    )
+
+    return ModelInfoResponse(
+        model_id=model["model_id"],
+        base_model=model["base_model"],
+        lora_config=model["lora_config"],
+        status=model["status"],
+        model_data=model_data
+    )
 
 
 @app.post("/api/v1/unload_model", response_model=UnloadModelResponse)

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -227,7 +227,7 @@ async def root():
     """Root endpoint with API information."""
     return {
         "name": "Tinker API Mock",
-        "version": "1.0.0",
+        "version": "0.0.1",
         "endpoints": {
             "models": ["/api/v1/create_model", "/api/v1/get_info"],
             "training": ["/api/v1/forward_backward", "/api/v1/optim_step"],

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -1,0 +1,354 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from typing import Optional, Literal, Any, Dict, List
+from uuid import uuid4
+
+app = FastAPI(title="Tinker API Mock", version="1.0.0")
+
+# In-memory storage for models
+models_db: Dict[str, Dict[str, Any]] = {}
+checkpoints_db: Dict[str, List[Dict[str, Any]]] = {}
+
+
+# Pydantic Models
+class LoRAConfig(BaseModel):
+    r: int = 8
+    lora_alpha: int = 16
+    target_modules: Optional[List[str]] = None
+    lora_dropout: float = 0.05
+
+
+class CreateModelRequest(BaseModel):
+    base_model: str
+    lora_config: Optional[LoRAConfig] = None
+    type: Optional[Literal["lora", "full"]] = "lora"
+
+
+class CreateModelResponse(BaseModel):
+    model_id: str
+    base_model: str
+    lora_config: Optional[LoRAConfig] = None
+    status: str = "created"
+
+
+class ModelInfoResponse(BaseModel):
+    model_id: str
+    base_model: str
+    lora_config: Optional[LoRAConfig] = None
+    status: str
+
+
+class UnloadModelResponse(BaseModel):
+    model_id: str
+    status: str = "unloaded"
+
+
+class ForwardInput(BaseModel):
+    input_ids: List[List[int]]
+    attention_mask: Optional[List[List[int]]] = None
+
+
+class ForwardBackwardInput(BaseModel):
+    input_ids: List[List[int]]
+    labels: List[List[int]]
+    attention_mask: Optional[List[List[int]]] = None
+
+
+class AdamParams(BaseModel):
+    lr: float = 1e-4
+    betas: tuple[float, float] = (0.9, 0.999)
+    eps: float = 1e-8
+    weight_decay: float = 0.0
+
+
+class OptimStepRequest(BaseModel):
+    model_id: str
+    adam_params: AdamParams
+    type: Optional[str] = None
+
+
+class SamplingParams(BaseModel):
+    temperature: float = 1.0
+    top_p: float = 1.0
+    top_k: int = -1
+    max_tokens: int = 100
+    stop: Optional[List[str]] = None
+
+
+class SampleRequest(BaseModel):
+    prompt: str
+    sampling_params: SamplingParams
+    num_samples: int = 1
+    base_model: Optional[str] = None
+    model_path: Optional[str] = None
+
+
+class SampleResponse(BaseModel):
+    samples: List[str]
+    prompt: str
+
+
+class SaveWeightsRequest(BaseModel):
+    model_id: str
+    path: Optional[str] = None
+    type: Optional[str] = None
+
+
+class SaveWeightsResponse(BaseModel):
+    model_id: str
+    path: str
+    status: str = "saved"
+
+
+class LoadWeightsRequest(BaseModel):
+    model_id: str
+    path: str
+    type: Optional[str] = None
+
+
+class LoadWeightsResponse(BaseModel):
+    model_id: str
+    path: str
+    status: str = "loaded"
+
+
+class Checkpoint(BaseModel):
+    checkpoint_id: str
+    model_id: str
+    path: str
+    created_at: str
+
+
+class FutureResponse(BaseModel):
+    future_id: str
+    status: str = "pending"
+
+
+class TelemetryEvent(BaseModel):
+    event: str
+    event_id: str
+    event_session_index: int
+    severity: str
+    timestamp: str
+    properties: Optional[Dict[str, Any]] = None
+
+
+class TelemetryRequest(BaseModel):
+    events: List[TelemetryEvent]
+    platform: str
+    sdk_version: str
+    session_id: str
+
+
+class TelemetryResponse(BaseModel):
+    status: Literal["accepted"] = "accepted"
+
+
+class SupportedModel(BaseModel):
+    model_name: Optional[str] = None
+
+
+class GetServerCapabilitiesResponse(BaseModel):
+    supported_models: List[SupportedModel]
+
+
+# Models endpoints
+@app.post("/api/v1/create_model", response_model=CreateModelResponse)
+async def create_model(request: CreateModelRequest):
+    """Create a new model, optionally with a LoRA adapter."""
+    model_id = f"model_{uuid4().hex[:8]}"
+
+    model_data = {
+        "model_id": model_id,
+        "base_model": request.base_model,
+        "lora_config": request.lora_config,
+        "status": "created"
+    }
+
+    models_db[model_id] = model_data
+    checkpoints_db[model_id] = []
+
+    return CreateModelResponse(**model_data)
+
+
+@app.post("/api/v1/get_info", response_model=ModelInfoResponse)
+async def get_model_info(model_id: str, type: Optional[str] = None):
+    """Retrieve information about the current model."""
+    if model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    return ModelInfoResponse(**models_db[model_id])
+
+
+@app.post("/api/v1/unload_model", response_model=UnloadModelResponse)
+async def unload_model(model_id: str, type: Optional[str] = None):
+    """Unload model weights and end user session."""
+    if model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    models_db[model_id]["status"] = "unloaded"
+
+    return UnloadModelResponse(model_id=model_id, status="unloaded")
+
+
+# Training endpoints
+@app.post("/api/v1/forward", response_model=FutureResponse)
+async def forward(model_id: str, forward_input: ForwardInput):
+    """Perform forward pass through the model."""
+    if model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    future_id = f"future_{uuid4().hex[:8]}"
+    return FutureResponse(future_id=future_id, status="completed")
+
+
+@app.post("/api/v1/forward_backward", response_model=FutureResponse)
+async def forward_backward(model_id: str, forward_backward_input: ForwardBackwardInput):
+    """Compute and accumulate gradients."""
+    if model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    future_id = f"future_{uuid4().hex[:8]}"
+    return FutureResponse(future_id=future_id, status="completed")
+
+
+@app.post("/api/v1/optim_step", response_model=FutureResponse)
+async def optim_step(request: OptimStepRequest):
+    """Update model using accumulated gradients."""
+    if request.model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    future_id = f"future_{uuid4().hex[:8]}"
+    return FutureResponse(future_id=future_id, status="completed")
+
+
+# Sampling endpoints
+@app.post("/api/v1/sample", response_model=SampleResponse)
+async def sample(request: SampleRequest):
+    """Generate outputs from the model."""
+    samples = [
+        f"Generated sample {i+1} for prompt: {request.prompt}"
+        for i in range(request.num_samples)
+    ]
+
+    return SampleResponse(samples=samples, prompt=request.prompt)
+
+
+@app.post("/api/v1/asample", response_model=FutureResponse)
+async def asample(request: SampleRequest):
+    """Async generate outputs from the model."""
+    future_id = f"future_{uuid4().hex[:8]}"
+    return FutureResponse(future_id=future_id, status="pending")
+
+
+# Weights endpoints
+@app.post("/api/v1/save_weights", response_model=SaveWeightsResponse)
+async def save_weights(request: SaveWeightsRequest):
+    """Save current model weights to disk."""
+    if request.model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    path = request.path or f"/checkpoints/{request.model_id}/weights.safetensors"
+
+    # Add checkpoint to the list
+    checkpoint = {
+        "checkpoint_id": f"ckpt_{uuid4().hex[:8]}",
+        "model_id": request.model_id,
+        "path": path,
+        "created_at": "2025-10-01T00:00:00Z"
+    }
+    checkpoints_db[request.model_id].append(checkpoint)
+
+    return SaveWeightsResponse(model_id=request.model_id, path=path, status="saved")
+
+
+@app.post("/api/v1/load_weights", response_model=LoadWeightsResponse)
+async def load_weights(request: LoadWeightsRequest):
+    """Load model weights from disk."""
+    if request.model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    return LoadWeightsResponse(model_id=request.model_id, path=request.path, status="loaded")
+
+
+@app.post("/api/v1/save_weights_for_sampler", response_model=SaveWeightsResponse)
+async def save_weights_for_sampler(request: SaveWeightsRequest):
+    """Save weights compatible with sampling/inference servers."""
+    if request.model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    path = request.path or f"/checkpoints/{request.model_id}/sampler_weights.safetensors"
+
+    return SaveWeightsResponse(model_id=request.model_id, path=path, status="saved")
+
+
+@app.get("/api/v1/models/{model_id}/checkpoints", response_model=List[Checkpoint])
+async def list_checkpoints(model_id: str):
+    """List available model checkpoints."""
+    if model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    return [Checkpoint(**ckpt) for ckpt in checkpoints_db.get(model_id, [])]
+
+
+@app.delete("/api/v1/training_runs/{model_id}/checkpoints/{checkpoint_id}")
+async def delete_checkpoint(model_id: str, checkpoint_id: str):
+    """Delete a checkpoint for a specific training run."""
+    if model_id not in models_db:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    checkpoints = checkpoints_db.get(model_id, [])
+    original_len = len(checkpoints)
+    checkpoints_db[model_id] = [
+        ckpt for ckpt in checkpoints if ckpt["checkpoint_id"] != checkpoint_id
+    ]
+
+    if len(checkpoints_db[model_id]) == original_len:
+        raise HTTPException(status_code=404, detail="Checkpoint not found")
+
+    return {"status": "deleted", "checkpoint_id": checkpoint_id}
+
+
+# Service endpoints
+@app.get("/api/v1/get_server_capabilities", response_model=GetServerCapabilitiesResponse)
+async def get_server_capabilities():
+    """Retrieve information about supported models and server capabilities."""
+    # Return a list of commonly supported models
+    supported_models = [
+        SupportedModel(model_name="Qwen/Qwen3-8B"),
+    ]
+    return GetServerCapabilitiesResponse(supported_models=supported_models)
+
+
+# Telemetry endpoint
+@app.post("/api/v1/telemetry", response_model=TelemetryResponse)
+async def send_telemetry(request: TelemetryRequest):
+    """Accept batches of SDK telemetry events for analytics and diagnostics."""
+    # Just acknowledge receipt without doing anything
+    return TelemetryResponse(status="accepted")
+
+
+@app.get("/")
+async def root():
+    """Root endpoint with API information."""
+    return {
+        "name": "Tinker API Mock",
+        "version": "1.0.0",
+        "endpoints": {
+            "models": ["/api/v1/create_model", "/api/v1/get_info", "/api/v1/unload_model"],
+            "training": ["/api/v1/forward", "/api/v1/forward_backward", "/api/v1/optim_step"],
+            "sampling": ["/api/v1/sample", "/api/v1/asample"],
+            "weights": [
+                "/api/v1/save_weights",
+                "/api/v1/load_weights",
+                "/api/v1/save_weights_for_sampler",
+                "/api/v1/models/{model_id}/checkpoints"
+            ],
+            "telemetry": ["/api/v1/telemetry"]
+        }
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -1,41 +1,41 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from typing import Optional, Literal, Any, Dict, List
+from typing import Literal, Any
 from uuid import uuid4
 
 app = FastAPI(title="Tinker API Mock", version="1.0.0")
 
 # In-memory storage for models
-models_db: Dict[str, Dict[str, Any]] = {}
-futures_db: Dict[str, Dict[str, Any]] = {}
+models_db: dict[str, dict[str, Any]] = {}
+futures_db: dict[str, dict[str, Any]] = {}
 
 
 # Pydantic Models
 class LoRAConfig(BaseModel):
     r: int = 8
     lora_alpha: int = 16
-    target_modules: Optional[List[str]] = None
+    target_modules: list[str] | None = None
     lora_dropout: float = 0.05
 
 
 class CreateModelRequest(BaseModel):
     base_model: str
-    lora_config: Optional[LoRAConfig] = None
-    type: Optional[str] = None
+    lora_config: LoRAConfig | None = None
+    type: str | None = None
 
 
 class CreateModelResponse(BaseModel):
     model_id: str
     base_model: str
-    lora_config: Optional[LoRAConfig] = None
+    lora_config: LoRAConfig | None = None
     status: str = "created"
     request_id: str
 
 
 class ModelData(BaseModel):
     base_model: str
-    lora_config: Optional[LoRAConfig] = None
-    model_name: Optional[str] = None
+    lora_config: LoRAConfig | None = None
+    model_name: str | None = None
 
 
 class ModelInfoResponse(BaseModel):
@@ -46,7 +46,7 @@ class ModelInfoResponse(BaseModel):
 
 class ForwardBackwardInput(BaseModel):
     model_id: str
-    forward_backward_input: Dict[str, Any]
+    forward_backward_input: dict[str, Any]
 
 
 class AdamParams(BaseModel):
@@ -59,13 +59,13 @@ class AdamParams(BaseModel):
 class OptimStepRequest(BaseModel):
     model_id: str
     adam_params: AdamParams
-    type: Optional[str] = None
+    type: str | None = None
 
 
 class FutureResponse(BaseModel):
     future_id: str
     status: str = "pending"
-    request_id: Optional[str] = None
+    request_id: str | None = None
 
 
 class TelemetryEvent(BaseModel):
@@ -74,11 +74,11 @@ class TelemetryEvent(BaseModel):
     event_session_index: int
     severity: str
     timestamp: str
-    properties: Optional[Dict[str, Any]] = None
+    properties: dict[str, Any] | None = None
 
 
 class TelemetryRequest(BaseModel):
-    events: List[TelemetryEvent]
+    events: list[TelemetryEvent]
     platform: str
     sdk_version: str
     session_id: str
@@ -89,11 +89,11 @@ class TelemetryResponse(BaseModel):
 
 
 class SupportedModel(BaseModel):
-    model_name: Optional[str] = None
+    model_name: str | None = None
 
 
 class GetServerCapabilitiesResponse(BaseModel):
-    supported_models: List[SupportedModel]
+    supported_models: list[SupportedModel]
 
 
 # Models endpoints
@@ -127,7 +127,7 @@ async def create_model(request: CreateModelRequest):
 
 class GetInfoRequest(BaseModel):
     model_id: str
-    type: Optional[str] = None
+    type: str | None = None
 
 
 @app.post("/api/v1/get_info", response_model=ModelInfoResponse)

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -41,8 +41,6 @@ class ModelData(BaseModel):
 
 class ModelInfoResponse(BaseModel):
     model_id: str
-    base_model: str
-    lora_config: Optional[LoRAConfig] = None
     status: str
     model_data: ModelData
 
@@ -205,8 +203,6 @@ async def get_model_info(request: GetInfoRequest):
 
     return ModelInfoResponse(
         model_id=model["model_id"],
-        base_model=model["base_model"],
-        lora_config=model["lora_config"],
         status=model["status"],
         model_data=model_data
     )

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing import Optional, Literal, Any, Dict, List
 from uuid import uuid4
 

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -178,13 +178,18 @@ async def create_model(request: CreateModelRequest):
     return CreateModelResponse(**model_data)
 
 
+class GetInfoRequest(BaseModel):
+    model_id: str
+    type: Optional[str] = None
+
+
 @app.post("/api/v1/get_info", response_model=ModelInfoResponse)
-async def get_model_info(model_id: str, type: Optional[str] = None):
+async def get_model_info(request: GetInfoRequest):
     """Retrieve information about the current model."""
-    if model_id not in models_db:
+    if request.model_id not in models_db:
         raise HTTPException(status_code=404, detail="Model not found")
 
-    return ModelInfoResponse(**models_db[model_id])
+    return ModelInfoResponse(**models_db[request.model_id])
 
 
 @app.post("/api/v1/unload_model", response_model=UnloadModelResponse)


### PR DESCRIPTION
This is a very first cut of the API, it is likely that there are mistakes and thing will change. For example currently I'm just setting the future_id to be the same as the request_id, we will see if that holds up.

Start the server with

```shell
uv run --with fastapi --with uvicorn python tx/tinker/api.py
```

Can be used like this:

```python
import tinker
service_client = tinker.ServiceClient(base_url="http://0.0.0.0:8000/", api_key="dummy")

print("Available models:")
for item in service_client.get_server_capabilities().supported_models:
    print("- " + item.model_name)

base_model = "Qwen/Qwen3-8B"
training_client = service_client.create_lora_training_client(
    base_model=base_model
)

tokenizer = training_client.get_tokenizer()
```

```python
# Create some training examples
examples = [
    {
        "input": "banana split",
        "output": "anana-bay plit-say"
    },
    {
        "input": "quantum physics",
        "output": "uantum-qay ysics-phay"
    },
    {
        "input": "donut shop",
        "output": "onut-day op-shay"
    },
    {
        "input": "pickle jar",
        "output": "ickle-pay ar-jay"
    },
    {
        "input": "space exploration",
        "output": "ace-spay exploration-way"
    },
    {
        "input": "rubber duck",
        "output": "ubber-ray uck-day"
    },
    {
        "input": "coding wizard",
        "output": "oding-cay izard-way"
    },
]
 
# Convert examples into the format expected by the training client
from tinker import types
 
# Get the tokenizer from the training client
tokenizer = training_client.get_tokenizer()
 
def process_example(example: dict, tokenizer) -> types.Datum:
    # Format the input with Input/Output template
    # For most real use cases, you'll want to use a renderer / chat template,
    # (see later docs) but here, we'll keep it simple.
    prompt = f"English: {example['input']}\nPig Latin:"
 
    prompt_tokens = tokenizer.encode(prompt, add_special_tokens=True)
    prompt_weights = [0] * len(prompt_tokens)
    # Add a space before the output string, and finish with double newline
    completion_tokens = tokenizer.encode(f" {example['output']}\n\n", add_special_tokens=False)
    completion_weights = [1] * len(completion_tokens)
 
    tokens = prompt_tokens + completion_tokens
    weights = prompt_weights + completion_weights
 
    input_tokens = tokens[:-1]
    target_tokens = tokens[1:] # We're predicting the next token, so targets need to be shifted.
    weights = weights[1:]
 
    # A datum is a single training example for the loss function.
    # It has model_input, which is the input sequence that'll be passed into the LLM,
    # loss_fn_inputs, which is a dictionary of extra inputs used by the loss function.
    return types.Datum(
        model_input=types.ModelInput.from_ints(tokens=input_tokens),
        loss_fn_inputs=dict(weights=weights, target_tokens=target_tokens)
    )
 
processed_examples = [process_example(ex, tokenizer) for ex in examples]
```

```python
fwdbwd_future = training_client.forward_backward(processed_examples, "cross_entropy")
fwdbwd_future.result()

optim_future = training_client.optim_step(types.AdamParams(learning_rate=1e-4))
optim_result = optim_future.result()
```