### PR TITLE
Add database to store requests and background engine to process them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ tpu = [
 tinker = [
     "tinker",
     "fastapi[standard]",
+    "sqlmodel",
+    "sqlalchemy[asyncio]",
+    "aiosqlite",
 ]
 
 dev = [

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -11,7 +11,7 @@ import asyncio
 import subprocess
 import logging
 
-from tx.tinker.models import ModelDB, FutureDB, DB_PATH
+from tx.tinker.models import ModelDB, FutureDB, DB_PATH, RequestType
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -155,7 +155,7 @@ async def create_model(request: CreateModelRequest, session: AsyncSession = Depe
 
     future_db = FutureDB(
         request_id=request_id,
-        request_type="create_model",
+        request_type=RequestType.CREATE_MODEL,
         model_id=model_id,
         request_data=request.model_dump(),
         result_data={
@@ -227,7 +227,7 @@ async def forward_backward(request: ForwardBackwardInput, session: AsyncSession 
 
     future_db = FutureDB(
         request_id=request_id,
-        request_type="forward_backward",
+        request_type=RequestType.FORWARD_BACKWARD,
         model_id=request.model_id,
         request_data=request.model_dump(),
         result_data=None,  # Will be filled by background worker
@@ -253,7 +253,7 @@ async def optim_step(request: OptimStepRequest, session: AsyncSession = Depends(
 
     future_db = FutureDB(
         request_id=request_id,
-        request_type="optim_step",
+        request_type=RequestType.OPTIM_STEP,
         model_id=request.model_id,
         request_data=request.model_dump(),
         result_data=None,  # Will be filled by background worker

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import Literal, Any
 from uuid import uuid4
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -177,7 +177,7 @@ async def create_model(request: CreateModelRequest):
                 "request_id": request_id
             }),
             status="completed",
-            completed_at=datetime.utcnow()
+            completed_at=datetime.now(timezone.utc)
         )
         session.add(future_db)
 

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import Literal, Any
 from uuid import uuid4
-from pathlib import Path
 from datetime import datetime
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -38,9 +37,8 @@ async def startup():
     await init_db()
 
     # Start background engine process using uv with tinker extra
-    engine_path = Path(__file__).parent / "engine.py"
     background_engine_process = subprocess.Popen(
-        ["uv", "run", "--extra", "tinker", "python", str(engine_path)],
+        ["uv", "run", "--extra", "tinker", "python", "-m", "tx.tinker.engine"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE
     )

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -13,15 +13,12 @@ import subprocess
 
 from tx.tinker.models import ModelDB, FutureDB, DB_PATH
 
-# SQLite database path
-DATABASE_URL = f"sqlite+aiosqlite:///{DB_PATH}"
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan event handler for startup and shutdown."""
     # Startup
-    app.state.db_engine = create_async_engine(DATABASE_URL, echo=False)
+    app.state.db_engine = create_async_engine(f"sqlite+aiosqlite:///{DB_PATH}", echo=False)
 
     async with app.state.db_engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-from typing import Literal, Any, Optional
+from typing import Literal, Any
 from uuid import uuid4
 from pathlib import Path
 from datetime import datetime
@@ -29,7 +29,7 @@ class ModelDB(SQLModel, table=True):
 
     model_id: str = Field(primary_key=True)
     base_model: str
-    lora_config: Optional[str] = None  # JSON string
+    lora_config: str | None = None  # JSON string
     status: str
     request_id: str
     created_at: datetime = Field(default_factory=datetime.utcnow)
@@ -40,12 +40,12 @@ class FutureDB(SQLModel, table=True):
 
     request_id: str = Field(primary_key=True)
     request_type: str  # "create_model", "forward_backward", "optim_step"
-    model_id: Optional[str] = None
+    model_id: str | None = None
     request_data: str  # JSON string with request details
-    result_data: Optional[str] = None  # JSON string with result, None if not yet processed
+    result_data: str | None = None  # JSON string with result, None if not yet processed
     status: str = "pending"  # "pending", "completed", "failed"
     created_at: datetime = Field(default_factory=datetime.utcnow)
-    completed_at: Optional[datetime] = None
+    completed_at: datetime | None = None
 
 
 async def init_db():

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -4,48 +4,24 @@ from typing import Literal, Any
 from uuid import uuid4
 from pathlib import Path
 from datetime import datetime
-from sqlmodel import SQLModel, Field, select
+from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 import json
 import asyncio
 import subprocess
 
+from tx.tinker.models import ModelDB, FutureDB, DB_PATH
+
 app = FastAPI(title="Tinker API Mock", version="0.0.1")
 
 # SQLite database path
-DB_PATH = Path(__file__).parent / "tinker.db"
 DATABASE_URL = f"sqlite+aiosqlite:///{DB_PATH}"
 
 engine = create_async_engine(DATABASE_URL, echo=False)
 
 # Background engine process
 background_engine_process = None
-
-
-# SQLModel table definitions
-class ModelDB(SQLModel, table=True):
-    __tablename__ = "models"
-
-    model_id: str = Field(primary_key=True)
-    base_model: str
-    lora_config: str | None = None  # JSON string
-    status: str
-    request_id: str
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-
-
-class FutureDB(SQLModel, table=True):
-    __tablename__ = "futures"
-
-    request_id: str = Field(primary_key=True)
-    request_type: str  # "create_model", "forward_backward", "optim_step"
-    model_id: str | None = None
-    request_data: str  # JSON string with request details
-    result_data: str | None = None  # JSON string with result, None if not yet processed
-    status: str = "pending"  # "pending", "completed", "failed"
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    completed_at: datetime | None = None
 
 
 async def init_db():

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -1,9 +1,12 @@
 """Background engine for processing training requests."""
 import time
+import logging
 from datetime import datetime, timezone
 from sqlmodel import create_engine, Session, select
 
 from tx.tinker.models import FutureDB, DB_PATH
+
+logger = logging.getLogger(__name__)
 
 
 class TinkerEngine:
@@ -58,7 +61,7 @@ class TinkerEngine:
                                 future.request_data
                             )
                         else:
-                            print(f"Unknown request type: {future.request_type}")
+                            logger.warning(f"Unknown request type: {future.request_type}")
                             continue
 
                         # Update the future with results
@@ -68,10 +71,10 @@ class TinkerEngine:
                         session.add(future)
                         session.commit()
 
-                        print(f"Completed {future.request_type} request {future.request_id}")
+                        logger.info(f"Completed {future.request_type} request {future.request_id}")
 
                     except Exception as e:
-                        print(f"Error processing request {future.request_id}: {e}")
+                        logger.error(f"Error processing request {future.request_id}: {e}")
                         future.result_data = {"error": str(e)}
                         future.status = "failed"
                         future.completed_at = datetime.now(timezone.utc)
@@ -83,12 +86,13 @@ class TinkerEngine:
 
     def run(self):
         """Entry point to start the engine."""
-        print("Starting background engine...")
+        logger.info("Starting background engine...")
         self.process_pending_requests()
 
 
 def main():
     """Entry point for the background engine."""
+    logging.basicConfig(level=logging.INFO)
     TinkerEngine().run()
 
 

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime, timezone
 from sqlmodel import create_engine, Session, select
 
-from tx.tinker.models import FutureDB, DB_PATH
+from tx.tinker.models import FutureDB, DB_PATH, RequestType
 
 logger = logging.getLogger(__name__)
 
@@ -48,13 +48,13 @@ class TinkerEngine:
                 for future in pending:
                     try:
                         # Process based on request type
-                        if future.request_type == "forward_backward":
+                        if future.request_type == RequestType.FORWARD_BACKWARD:
                             result_data = self.process_forward_backward(
                                 future.request_id,
                                 future.model_id,
                                 future.request_data
                             )
-                        elif future.request_type == "optim_step":
+                        elif future.request_type == RequestType.OPTIM_STEP:
                             result_data = self.process_optim_step(
                                 future.request_id,
                                 future.model_id,

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -1,7 +1,7 @@
 """Background engine for processing training requests."""
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlmodel import create_engine, Session, select
 
 from tx.tinker.models import FutureDB, DB_PATH
@@ -66,7 +66,7 @@ def process_pending_requests():
                         # Update the future with results
                         future.result_data = json.dumps(result_data)
                         future.status = "completed"
-                        future.completed_at = datetime.utcnow()
+                        future.completed_at = datetime.now(timezone.utc)
                         session.add(future)
                         session.commit()
 
@@ -76,7 +76,7 @@ def process_pending_requests():
                         print(f"Error processing request {future.request_id}: {e}")
                         future.result_data = json.dumps({"error": str(e)})
                         future.status = "failed"
-                        future.completed_at = datetime.utcnow()
+                        future.completed_at = datetime.now(timezone.utc)
                         session.add(future)
                         session.commit()
 

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -11,8 +11,7 @@ class TinkerEngine:
 
     def __init__(self, db_path=DB_PATH):
         """Initialize the engine with a database connection."""
-        database_url = f"sqlite:///{db_path}"
-        self.db_engine: Engine = create_engine(database_url, echo=False)
+        self.db_engine: Engine = create_engine(f"sqlite:///{db_path}", echo=False)
 
     def process_forward_backward(self, request_id: str, model_id: str, request_data: dict) -> dict:
         """Process a forward_backward request and return mock results."""
@@ -94,8 +93,7 @@ class TinkerEngine:
 
 def main():
     """Entry point for the background engine."""
-    engine = TinkerEngine()
-    engine.run()
+    TinkerEngine().run()
 
 
 if __name__ == "__main__":

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -2,13 +2,9 @@
 import json
 import time
 from datetime import datetime
-from pathlib import Path
 from sqlmodel import create_engine, Session, select
 
-# Import models from api.py
-import sys
-sys.path.append(str(Path(__file__).parent))
-from api import FutureDB, ModelDB, DB_PATH
+from tx.tinker.models import FutureDB, ModelDB, DB_PATH
 
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 engine = create_engine(DATABASE_URL, echo=False)

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -1,93 +1,101 @@
 """Background engine for processing training requests."""
 import time
 from datetime import datetime, timezone
-from sqlmodel import create_engine, Session, select
+from sqlmodel import create_engine, Session, select, Engine
 
 from tx.tinker.models import FutureDB, DB_PATH
 
-DATABASE_URL = f"sqlite:///{DB_PATH}"
-engine = create_engine(DATABASE_URL, echo=False)
 
+class TinkerEngine:
+    """Background engine for processing training requests."""
 
-def process_forward_backward(request_id: str, model_id: str, request_data: dict):
-    """Process a forward_backward request and return mock results."""
-    # Mock implementation - returns dummy loss
-    result = {
-        "loss_fn_output_type": "scalar",
-        "loss_fn_outputs": [{
-            "loss": {
-                "data": [0.5],
-                "dtype": "float32",
-                "shape": [1]
-            }
-        }],
-        "metrics": {}
-    }
-    return result
+    def __init__(self, db_path=DB_PATH):
+        """Initialize the engine with a database connection."""
+        database_url = f"sqlite:///{db_path}"
+        self.db_engine: Engine = create_engine(database_url, echo=False)
 
+    def process_forward_backward(self, request_id: str, model_id: str, request_data: dict) -> dict:
+        """Process a forward_backward request and return mock results."""
+        # Mock implementation - returns dummy loss
+        result = {
+            "loss_fn_output_type": "scalar",
+            "loss_fn_outputs": [{
+                "loss": {
+                    "data": [0.5],
+                    "dtype": "float32",
+                    "shape": [1]
+                }
+            }],
+            "metrics": {}
+        }
+        return result
 
-def process_optim_step(request_id: str, model_id: str, request_data: dict):
-    """Process an optim_step request and return empty result."""
-    # Mock implementation - returns empty dict
-    return {}
+    def process_optim_step(self, request_id: str, model_id: str, request_data: dict) -> dict:
+        """Process an optim_step request and return empty result."""
+        # Mock implementation - returns empty dict
+        return {}
 
+    def process_pending_requests(self):
+        """Main loop to process pending requests."""
+        while True:
+            try:
+                with Session(self.db_engine) as session:
+                    # Get all pending requests
+                    statement = select(FutureDB).where(FutureDB.status == "pending")
+                    pending = session.exec(statement).all()
 
-def process_pending_requests():
-    """Main loop to process pending requests."""
-    while True:
-        try:
-            with Session(engine) as session:
-                # Get all pending requests
-                statement = select(FutureDB).where(FutureDB.status == "pending")
-                pending = session.exec(statement).all()
+                    for future in pending:
+                        try:
+                            # Process based on request type
+                            if future.request_type == "forward_backward":
+                                result_data = self.process_forward_backward(
+                                    future.request_id,
+                                    future.model_id,
+                                    future.request_data
+                                )
+                            elif future.request_type == "optim_step":
+                                result_data = self.process_optim_step(
+                                    future.request_id,
+                                    future.model_id,
+                                    future.request_data
+                                )
+                            else:
+                                print(f"Unknown request type: {future.request_type}")
+                                continue
 
-                for future in pending:
-                    try:
-                        # Process based on request type
-                        if future.request_type == "forward_backward":
-                            result_data = process_forward_backward(
-                                future.request_id,
-                                future.model_id,
-                                future.request_data
-                            )
-                        elif future.request_type == "optim_step":
-                            result_data = process_optim_step(
-                                future.request_id,
-                                future.model_id,
-                                future.request_data
-                            )
-                        else:
-                            print(f"Unknown request type: {future.request_type}")
-                            continue
+                            # Update the future with results
+                            future.result_data = result_data
+                            future.status = "completed"
+                            future.completed_at = datetime.now(timezone.utc)
+                            session.add(future)
+                            session.commit()
 
-                        # Update the future with results
-                        future.result_data = result_data
-                        future.status = "completed"
-                        future.completed_at = datetime.now(timezone.utc)
-                        session.add(future)
-                        session.commit()
+                            print(f"Completed {future.request_type} request {future.request_id}")
 
-                        print(f"Completed {future.request_type} request {future.request_id}")
+                        except Exception as e:
+                            print(f"Error processing request {future.request_id}: {e}")
+                            future.result_data = {"error": str(e)}
+                            future.status = "failed"
+                            future.completed_at = datetime.now(timezone.utc)
+                            session.add(future)
+                            session.commit()
 
-                    except Exception as e:
-                        print(f"Error processing request {future.request_id}: {e}")
-                        future.result_data = {"error": str(e)}
-                        future.status = "failed"
-                        future.completed_at = datetime.now(timezone.utc)
-                        session.add(future)
-                        session.commit()
+            except Exception as e:
+                print(f"Error in main loop: {e}")
 
-        except Exception as e:
-            print(f"Error in main loop: {e}")
+            # Poll every 100ms
+            time.sleep(0.1)
 
-        # Poll every 100ms
-        time.sleep(0.1)
+    def run(self):
+        """Entry point to start the engine."""
+        print("Starting background engine...")
+        self.process_pending_requests()
 
 
 def main():
     """Entry point for the background engine."""
-    print("Starting background engine...")
-    process_pending_requests()
+    engine = TinkerEngine()
+    engine.run()
 
 
 if __name__ == "__main__":

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -1,7 +1,7 @@
 """Background engine for processing training requests."""
 import time
 from datetime import datetime, timezone
-from sqlmodel import create_engine, Session, select, Engine
+from sqlmodel import create_engine, Session, select
 
 from tx.tinker.models import FutureDB, DB_PATH
 
@@ -11,7 +11,7 @@ class TinkerEngine:
 
     def __init__(self, db_path=DB_PATH):
         """Initialize the engine with a database connection."""
-        self.db_engine: Engine = create_engine(f"sqlite:///{db_path}", echo=False)
+        self.db_engine = create_engine(f"sqlite:///{db_path}", echo=False)
 
     def process_forward_backward(self, request_id: str, model_id: str, request_data: dict) -> dict:
         """Process a forward_backward request and return mock results."""

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -1,0 +1,101 @@
+"""Background engine for processing training requests."""
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+from sqlmodel import create_engine, Session, select
+
+# Import models from api.py
+import sys
+sys.path.append(str(Path(__file__).parent))
+from api import FutureDB, ModelDB, DB_PATH
+
+DATABASE_URL = f"sqlite:///{DB_PATH}"
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+def process_forward_backward(request_id: str, model_id: str, request_data: dict):
+    """Process a forward_backward request and return mock results."""
+    # Mock implementation - returns dummy loss
+    result = {
+        "loss_fn_output_type": "scalar",
+        "loss_fn_outputs": [{
+            "loss": {
+                "data": [0.5],
+                "dtype": "float32",
+                "shape": [1]
+            }
+        }],
+        "metrics": {}
+    }
+    return result
+
+
+def process_optim_step(request_id: str, model_id: str, request_data: dict):
+    """Process an optim_step request and return empty result."""
+    # Mock implementation - returns empty dict
+    return {}
+
+
+def process_pending_requests():
+    """Main loop to process pending requests."""
+    while True:
+        try:
+            with Session(engine) as session:
+                # Get all pending requests
+                statement = select(FutureDB).where(FutureDB.status == "pending")
+                pending = session.exec(statement).all()
+
+                for future in pending:
+                    try:
+                        request_data = json.loads(future.request_data)
+
+                        # Process based on request type
+                        if future.request_type == "forward_backward":
+                            result_data = process_forward_backward(
+                                future.request_id,
+                                future.model_id,
+                                request_data
+                            )
+                        elif future.request_type == "optim_step":
+                            result_data = process_optim_step(
+                                future.request_id,
+                                future.model_id,
+                                request_data
+                            )
+                        else:
+                            print(f"Unknown request type: {future.request_type}")
+                            continue
+
+                        # Update the future with results
+                        future.result_data = json.dumps(result_data)
+                        future.status = "completed"
+                        future.completed_at = datetime.utcnow()
+                        session.add(future)
+                        session.commit()
+
+                        print(f"Completed {future.request_type} request {future.request_id}")
+
+                    except Exception as e:
+                        print(f"Error processing request {future.request_id}: {e}")
+                        future.result_data = json.dumps({"error": str(e)})
+                        future.status = "failed"
+                        future.completed_at = datetime.utcnow()
+                        session.add(future)
+                        session.commit()
+
+        except Exception as e:
+            print(f"Error in main loop: {e}")
+
+        # Poll every 100ms
+        time.sleep(0.1)
+
+
+def main():
+    """Entry point for the background engine."""
+    print("Starting background engine...")
+    process_pending_requests()
+
+
+if __name__ == "__main__":
+    main()

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -4,7 +4,7 @@ import time
 from datetime import datetime
 from sqlmodel import create_engine, Session, select
 
-from tx.tinker.models import FutureDB, ModelDB, DB_PATH
+from tx.tinker.models import FutureDB, DB_PATH
 
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 engine = create_engine(DATABASE_URL, echo=False)

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -1,5 +1,4 @@
 """Background engine for processing training requests."""
-import json
 import time
 from datetime import datetime, timezone
 from sqlmodel import create_engine, Session, select
@@ -44,27 +43,25 @@ def process_pending_requests():
 
                 for future in pending:
                     try:
-                        request_data = json.loads(future.request_data)
-
                         # Process based on request type
                         if future.request_type == "forward_backward":
                             result_data = process_forward_backward(
                                 future.request_id,
                                 future.model_id,
-                                request_data
+                                future.request_data
                             )
                         elif future.request_type == "optim_step":
                             result_data = process_optim_step(
                                 future.request_id,
                                 future.model_id,
-                                request_data
+                                future.request_data
                             )
                         else:
                             print(f"Unknown request type: {future.request_type}")
                             continue
 
                         # Update the future with results
-                        future.result_data = json.dumps(result_data)
+                        future.result_data = result_data
                         future.status = "completed"
                         future.completed_at = datetime.now(timezone.utc)
                         session.add(future)
@@ -74,7 +71,7 @@ def process_pending_requests():
 
                     except Exception as e:
                         print(f"Error processing request {future.request_id}: {e}")
-                        future.result_data = json.dumps({"error": str(e)})
+                        future.result_data = {"error": str(e)}
                         future.status = "failed"
                         future.completed_at = datetime.now(timezone.utc)
                         session.add(future)

--- a/tx/tinker/models.py
+++ b/tx/tinker/models.py
@@ -15,6 +15,13 @@ class RequestType(str, Enum):
     OPTIM_STEP = "optim_step"
 
 
+class RequestStatus(str, Enum):
+    """Status of a request."""
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
 # SQLModel table definitions
 class ModelDB(SQLModel, table=True):
     __tablename__ = "models"
@@ -35,6 +42,6 @@ class FutureDB(SQLModel, table=True):
     model_id: str | None = None
     request_data: dict = Field(sa_type=JSON)
     result_data: dict | None = Field(default=None, sa_type=JSON)
-    status: str = Field(default="pending", index=True)  # "pending", "completed", "failed"
+    status: RequestStatus = Field(default=RequestStatus.PENDING, index=True)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None

--- a/tx/tinker/models.py
+++ b/tx/tinker/models.py
@@ -1,0 +1,32 @@
+"""Database models for the Tinker API."""
+from datetime import datetime
+from pathlib import Path
+from sqlmodel import SQLModel, Field
+
+# SQLite database path
+DB_PATH = Path(__file__).parent / "tinker.db"
+
+
+# SQLModel table definitions
+class ModelDB(SQLModel, table=True):
+    __tablename__ = "models"
+
+    model_id: str = Field(primary_key=True)
+    base_model: str
+    lora_config: str | None = None  # JSON string
+    status: str
+    request_id: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class FutureDB(SQLModel, table=True):
+    __tablename__ = "futures"
+
+    request_id: str = Field(primary_key=True)
+    request_type: str  # "create_model", "forward_backward", "optim_step"
+    model_id: str | None = None
+    request_data: str  # JSON string with request details
+    result_data: str | None = None  # JSON string with result, None if not yet processed
+    status: str = "pending"  # "pending", "completed", "failed"
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    completed_at: datetime | None = None

--- a/tx/tinker/models.py
+++ b/tx/tinker/models.py
@@ -1,10 +1,18 @@
 """Database models for the Tinker API."""
 from datetime import datetime, timezone
 from pathlib import Path
+from enum import Enum
 from sqlmodel import SQLModel, Field, JSON
 
 # SQLite database path
 DB_PATH = Path(__file__).parent / "tinker.db"
+
+
+class RequestType(str, Enum):
+    """Types of requests that can be processed."""
+    CREATE_MODEL = "create_model"
+    FORWARD_BACKWARD = "forward_backward"
+    OPTIM_STEP = "optim_step"
 
 
 # SQLModel table definitions
@@ -23,7 +31,7 @@ class FutureDB(SQLModel, table=True):
     __tablename__ = "futures"
 
     request_id: str = Field(primary_key=True, index=True)
-    request_type: str  # "create_model", "forward_backward", "optim_step"
+    request_type: RequestType
     model_id: str | None = None
     request_data: dict = Field(sa_type=JSON)
     result_data: dict | None = Field(default=None, sa_type=JSON)

--- a/tx/tinker/models.py
+++ b/tx/tinker/models.py
@@ -1,5 +1,5 @@
 """Database models for the Tinker API."""
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from sqlmodel import SQLModel, Field
 
@@ -16,7 +16,7 @@ class ModelDB(SQLModel, table=True):
     lora_config: str | None = None  # JSON string
     status: str
     request_id: str
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class FutureDB(SQLModel, table=True):
@@ -28,5 +28,5 @@ class FutureDB(SQLModel, table=True):
     request_data: str  # JSON string with request details
     result_data: str | None = None  # JSON string with result, None if not yet processed
     status: str = Field(default="pending", index=True)  # "pending", "completed", "failed"
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None

--- a/tx/tinker/models.py
+++ b/tx/tinker/models.py
@@ -1,7 +1,7 @@
 """Database models for the Tinker API."""
 from datetime import datetime, timezone
 from pathlib import Path
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel, Field, JSON
 
 # SQLite database path
 DB_PATH = Path(__file__).parent / "tinker.db"
@@ -13,7 +13,7 @@ class ModelDB(SQLModel, table=True):
 
     model_id: str = Field(primary_key=True)
     base_model: str
-    lora_config: str | None = None  # JSON string
+    lora_config: dict | None = Field(default=None, sa_type=JSON)
     status: str
     request_id: str
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
@@ -25,8 +25,8 @@ class FutureDB(SQLModel, table=True):
     request_id: str = Field(primary_key=True, index=True)
     request_type: str  # "create_model", "forward_backward", "optim_step"
     model_id: str | None = None
-    request_data: str  # JSON string with request details
-    result_data: str | None = None  # JSON string with result, None if not yet processed
+    request_data: dict = Field(sa_type=JSON)
+    result_data: dict | None = Field(default=None, sa_type=JSON)
     status: str = Field(default="pending", index=True)  # "pending", "completed", "failed"
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None

--- a/tx/tinker/models.py
+++ b/tx/tinker/models.py
@@ -22,11 +22,11 @@ class ModelDB(SQLModel, table=True):
 class FutureDB(SQLModel, table=True):
     __tablename__ = "futures"
 
-    request_id: str = Field(primary_key=True)
+    request_id: str = Field(primary_key=True, index=True)
     request_type: str  # "create_model", "forward_backward", "optim_step"
     model_id: str | None = None
     request_data: str  # JSON string with request details
     result_data: str | None = None  # JSON string with result, None if not yet processed
-    status: str = "pending"  # "pending", "completed", "failed"
+    status: str = Field(default="pending", index=True)  # "pending", "completed", "failed"
     created_at: datetime = Field(default_factory=datetime.utcnow)
     completed_at: datetime | None = None


### PR DESCRIPTION
This is a first iteration of adding a database to store data about requests, and a background engine to process them. We are choosing sqlite as a DB right now to make things simple, but going forward for more serious use cases people might also be using postgres etc. Also we might want to introduce more types for the different requests and replies. Right now I'm keeping that open because it will likely evolve a decent amount.