### PR TITLE
First cut at implementing the Tinker API

### DIFF
--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -31,12 +31,12 @@ def test_capabilities(service_client):
     """Test the get_server_capabilities endpoint."""
     capabilities = service_client.get_server_capabilities()
     model_names = [item.model_name for item in capabilities.supported_models]
-    assert "Qwen/Qwen3-8B" in model_names
+    assert "Qwen/Qwen3-0.6B" in model_names
 
 
 def test_training_workflow(service_client):
     """Test a complete training workflow."""
-    base_model = "Qwen/Qwen3-8B"
+    base_model = "Qwen/Qwen3-0.6B"
     training_client = service_client.create_lora_training_client(
         base_model=base_model
     )

--- a/tests/tinker/test_api.py
+++ b/tests/tinker/test_api.py
@@ -86,3 +86,7 @@ def test_training_workflow(service_client):
     assert optim_result is not None
     assert fwdbwd_result.loss_fn_output_type == "scalar"
     assert len(fwdbwd_result.loss_fn_outputs) > 0
+
+    # Get a checkpoint
+    sampling_path = training_client.save_weights_for_sampler(name="0000").result().path
+    assert sampling_path is not None

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI, HTTPException, Depends, Request
 from pydantic import BaseModel
 from typing import Literal, Any, AsyncGenerator
 from uuid import uuid4
-from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -158,15 +158,8 @@ async def create_model(request: CreateModelRequest, session: AsyncSession = Depe
         request_type=RequestType.CREATE_MODEL,
         model_id=model_id,
         request_data=request.model_dump(),
-        result_data={
-            "model_id": model_id,
-            "base_model": request.base_model,
-            "lora_config": request.lora_config.model_dump() if request.lora_config else None,
-            "status": "created",
-            "request_id": request_id
-        },
-        status=RequestStatus.COMPLETED,
-        completed_at=datetime.now(timezone.utc)
+        result_data=None,  # Will be filled by background worker
+        status=RequestStatus.PENDING
     )
     session.add(future_db)
 

--- a/tx/tinker/api.py
+++ b/tx/tinker/api.py
@@ -269,7 +269,7 @@ async def optim_step(request: OptimStepRequest, session: AsyncSession = Depends(
 async def get_server_capabilities():
     """Retrieve information about supported models and server capabilities."""
     supported_models = [
-        SupportedModel(model_name="Qwen/Qwen3-8B"),
+        SupportedModel(model_name="Qwen/Qwen3-0.6B"),
     ]
     return GetServerCapabilitiesResponse(supported_models=supported_models)
 

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -66,14 +66,12 @@ class TinkerEngine:
 
     def process_forward_backward(self, request_id: str, model_id: str, request_data: dict) -> dict:
         """Process a forward_backward request and return real loss and gradients."""
-        # Check if model is loaded
         if model_id not in self.models:
             raise ValueError(f"Model {model_id} not loaded")
 
         model_info = self.models[model_id]
         model = model_info["model"]
 
-        # Extract batch data from request
         forward_backward_input = request_data.get("forward_backward_input", {})
 
         # Extract tokens from examples
@@ -160,7 +158,6 @@ class TinkerEngine:
         model = model_info["model"]
         config = model_info["config"]
 
-        # Get the optional checkpoint_id from request path
         checkpoint_id = request_data.get("path")
         if not checkpoint_id:
             checkpoint_id = f"checkpoint_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
@@ -168,7 +165,6 @@ class TinkerEngine:
             # Make sure the user cannot store checkpoints in places like ../../<important file>
             checkpoint_id = Path(checkpoint_id).name
 
-        # Create the output directory: CHECKPOINTS_BASE_PATH/{model_id}/{checkpoint_id}
         output_dir = CHECKPOINTS_BASE_PATH / model_id / checkpoint_id
         output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -177,7 +173,6 @@ class TinkerEngine:
         config.save_pretrained(output_dir)
         logger.info(f"Saved weights for sampler for model {model_id} to {output_dir}")
 
-        # Return a tinker URI
         return {
             "path": f"tinker://{model_id}/{checkpoint_id}",
             "type": "save_weights_for_sampler"

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -100,13 +100,7 @@ class TinkerEngine:
         if self.accumulated_grads[model_id] is None:
             self.accumulated_grads[model_id] = grads
         else:
-            # Add to accumulated gradients
-            accumulated = self.accumulated_grads[model_id]
-            for path in nnx.to_flat_state(grads):
-                acc_state = nnx.to_flat_state(accumulated)
-                grad_state = nnx.to_flat_state(grads)
-                # Simple accumulation - in practice you'd iterate through the state tree
-                self.accumulated_grads[model_id] = grads  # For now, just replace
+            raise NotImplementedError("Gradient accumulation not yet implemented")
 
         # Return loss in the expected format
         loss_value = float(loss)

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -163,8 +163,10 @@ class TinkerEngine:
         # Get the optional checkpoint_id from request path
         checkpoint_id = request_data.get("path")
         if not checkpoint_id:
-            # Generate a default checkpoint ID based on timestamp
             checkpoint_id = f"checkpoint_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+        else:
+            # Make sure the user cannot store checkpoints in places like ../../<important file>
+            checkpoint_id = Path(checkpoint_id).name
 
         # Create the output directory: CHECKPOINTS_BASE_PATH/{model_id}/{checkpoint_id}
         output_dir = CHECKPOINTS_BASE_PATH / model_id / checkpoint_id

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -137,17 +137,9 @@ class TinkerEngine:
             logger.warning(f"No accumulated gradients for model {model_id}, skipping optimizer step")
             return {}
 
-        # Update optimizer learning rate if provided
-        # adam_params = request_data.get("adam_params", {})
-        # if "lr" in adam_params:
-        #     lr = adam_params["lr"]
-        #     weight_decay = adam_params.get("weight_decay", 0.0)
-        #     # Recreate optimizer with new learning rate
-        #     optimizer = nnx.Optimizer(model, optax.adamw(lr, weight_decay=weight_decay), wrt=nnx.Param)
-        #     model_info["optimizer"] = optimizer
-
-        # Apply gradients
-        optimizer.update(model, grads)
+        adam_params = request_data.get("adam_params", {})
+        # TODO: Add weight decay and other parameter handling here
+        optimizer.update(model, grads, learning_rate=adam_params["lr"])
 
         # Clear accumulated gradients
         self.accumulated_grads[model_id] = None

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -11,23 +11,9 @@ import optax
 from transformers import AutoConfig
 
 from tx.tinker.models import FutureDB, ModelDB, DB_PATH, RequestType, RequestStatus
-from tx.utils.models import get_dtype, get_model_class, get_optimizer, OptimizerName
+from tx.utils.models import get_dtype, get_model_class
 
 logger = logging.getLogger(__name__)
-
-
-def convert_tensor_to_list(tensor_data):
-    """Convert tensor data from dict format to list.
-
-    Args:
-        tensor_data: Either a list or a dict with 'data' and optional 'shape' keys
-
-    Returns:
-        list: The tensor data as a flat list
-    """
-    if isinstance(tensor_data, dict) and "data" in tensor_data:
-        return tensor_data["data"]
-    return list(tensor_data)
 
 
 def loss_fn(model, batch):
@@ -92,7 +78,7 @@ class TinkerEngine:
         for item in data:
             tokens = [t for chunk in item["model_input"]["chunks"] for t in chunk["tokens"]]
             input_ids_list.append(tokens)
-            target_tokens = convert_tensor_to_list(item["loss_fn_inputs"]["target_tokens"])
+            target_tokens = item["loss_fn_inputs"]["target_tokens"]["data"]
             target_list.append(target_tokens)
 
         # Pad sequences to same length

--- a/tx/tinker/engine.py
+++ b/tx/tinker/engine.py
@@ -44,6 +44,7 @@ class TinkerEngine:
         with jax.set_mesh(mesh):
             model = model_class(config, dtype=get_dtype(config.dtype), rngs=nnx.Rngs(0))
             # Initialize optimizer with default Adam settings
+            # (TODO: This might not actually be super great, it is worth thinking about how to do that better)
             optimizer = nnx.Optimizer(model, optax.adamw(1e-4), wrt=nnx.Param)
 
         self.models[model_id] = {

--- a/tx/tinker/models.py
+++ b/tx/tinker/models.py
@@ -13,6 +13,7 @@ class RequestType(str, Enum):
     CREATE_MODEL = "create_model"
     FORWARD_BACKWARD = "forward_backward"
     OPTIM_STEP = "optim_step"
+    SAVE_WEIGHTS_FOR_SAMPLER = "save_weights_for_sampler"
 
 
 class RequestStatus(str, Enum):


### PR DESCRIPTION
This is a first pass with many gaps, but already works end-to-end. Here is how you can use it:

- Clone the repo https://github.com/tx-project/tx and `cd tx`
- Start the server with
```
uv run --extra tinker python tx/tinker/api.py
```

- Then run a python script like this:
```python
import tinker
service_client = tinker.ServiceClient(base_url="http://localhost:8000", api_key="dummy")
training_client = service_client.create_lora_training_client(base_model="Qwen/Qwen3-0.6B")
sampling_path = training_client.save_weights_for_sampler(name="0000").result().path
```

You can e.g. run the pig latin example in https://tinker-docs.thinkingmachines.ai/training-sampling (currently you have to skip the printing of the logprobs since that's not implemented yet -- instead you can just print the loss that is returned)

To perform inference from the saved model, you can add the tokenizer
```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
tokenizer.save_pretrained("/your/model/path")
```

You can then e.g. server your model with something like
```
uv run --with vllm vllm serve /tmp/tx_checkpoints/model_10f20543/0000
```

and then e.g. do inference via
```
curl http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{"model": "/tmp/tx_checkpoints/model_10f20543/0000", "prompt": "banana split", "max_tokens": 32, "temperature": 0}'
```

Big omissions that are currently not implemented that we plan to implement:

1. Token weights for the training
2. LoRA (currently it is full parameter finetuning)
3. Actual proper downloading of checkpoints instead of just saving them to disk